### PR TITLE
feat(smtp): add internal SMTP relay

### DIFF
--- a/apps/smtp/app.ts
+++ b/apps/smtp/app.ts
@@ -1,0 +1,69 @@
+import { App, Size } from "cdk8s";
+import { Cpu, EnvValue } from "cdk8s-plus-33";
+import { basename } from "path";
+import { AppPlus } from "../../lib/app-plus";
+import { NewArgoApp } from "../../lib/argo";
+import { DEFAULT_APP_PROPS } from "../../lib/consts";
+import { NewKustomize } from "../../lib/kustomize";
+import { BitwardenSecret } from "../../lib/secrets";
+
+const namespace = basename(__dirname);
+const name = namespace;
+const app = new App(DEFAULT_APP_PROPS(namespace));
+const port = 25;
+
+NewArgoApp(name, {
+  namespace,
+  autoUpdate: {
+    images: [
+      {
+        image: "boky/postfix",
+        strategy: "semver",
+      },
+    ],
+  },
+});
+
+// TODO: replace with the Bitwarden secret UUID for the Cloudflare SMTP API token
+const secrets = new BitwardenSecret(app, `${name}-secrets`, {
+  name,
+  namespace,
+  data: {
+    RELAYHOST_PASSWORD: "88c10a6c-268a-412a-b3d0-b4230026ba80",
+  },
+});
+
+new AppPlus(app, `${name}-app`, {
+  name,
+  namespace,
+  image: "boky/postfix:latest",
+  disableIngress: true,
+  ports: [port],
+  resources: {
+    cpu: {
+      request: Cpu.millis(10),
+      limit: Cpu.millis(200),
+    },
+    memory: {
+      request: Size.mebibytes(64),
+      limit: Size.mebibytes(256),
+    },
+  },
+  extraEnv: {
+    // Upstream Cloudflare SMTP relay
+    RELAYHOST: EnvValue.fromValue("[smtp.mx.cloudflare.net]:465"),
+    RELAYHOST_USERNAME: EnvValue.fromValue("api_token"),
+    RELAYHOST_PASSWORD: EnvValue.fromSecretValue({
+      secret: secrets.secret,
+      key: "RELAYHOST_PASSWORD",
+    }),
+    // Port 465 uses implicit TLS (SMTPS/wrappermode) rather than STARTTLS
+    POSTFIX_smtp_tls_security_level: EnvValue.fromValue("encrypt"),
+    POSTFIX_smtp_tls_wrappermode: EnvValue.fromValue("yes"),
+    // Allow any sender domain — internal clients won't always share a common domain
+    ALLOW_EMPTY_SENDER_DOMAINS: EnvValue.fromValue("true"),
+  },
+});
+
+app.synth();
+NewKustomize(app.outdir);

--- a/dist/apps/smtp.yaml
+++ b/dist/apps/smtp.yaml
@@ -1,0 +1,43 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/name: smtp
+  name: smtp
+  namespace: argocd
+spec:
+  destination:
+    namespace: smtp
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: dist/smtp
+    repoURL: git@github.com:bjschafer/k8s-generators.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+---
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  labels:
+    app.kubernetes.io/name: smtp
+  name: smtp-updater
+  namespace: argocd
+spec:
+  applicationRefs:
+    - images:
+        - alias: postfix
+          commonUpdateSettings:
+            updateStrategy: semver
+          imageName: boky/postfix:latest
+      namePattern: smtp
+  namespace: argocd
+  writeBackConfig:
+    gitConfig:
+      branch: main
+    method: git

--- a/dist/smtp/Deployment.smtp.yaml
+++ b/dist/smtp/Deployment.smtp.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: generators
+    app.kubernetes.io/name: smtp
+  name: smtp
+  namespace: smtp
+spec:
+  minReadySeconds: 0
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      cdk8s.io/metadata.addr: smtp-app-smtp-app-deployment-c84da417
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: smtp
+        cdk8s.io/metadata.addr: smtp-app-smtp-app-deployment-c84da417
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: RELAYHOST
+              value: "[smtp.mx.cloudflare.net]:465"
+            - name: RELAYHOST_USERNAME
+              value: api_token
+            - name: RELAYHOST_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: RELAYHOST_PASSWORD
+                  name: smtp
+            - name: POSTFIX_smtp_tls_security_level
+              value: encrypt
+            - name: POSTFIX_smtp_tls_wrappermode
+              value: "yes"
+            - name: ALLOW_EMPTY_SENDER_DOMAINS
+              value: "true"
+          image: boky/postfix:latest
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: 3
+            tcpSocket:
+              port: 25
+          name: smtp
+          ports:
+            - containerPort: 25
+          readinessProbe:
+            failureThreshold: 3
+            tcpSocket:
+              port: 25
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: false
+      dnsPolicy: ClusterFirst
+      hostNetwork: false
+      restartPolicy: Always
+      securityContext:
+        fsGroupChangePolicy: Always
+        runAsNonRoot: false
+      setHostnameAsFQDN: false
+      shareProcessNamespace: false
+      terminationGracePeriodSeconds: 30

--- a/dist/smtp/ExternalSecret.smtp.yaml
+++ b/dist/smtp/ExternalSecret.smtp.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: smtp
+  namespace: smtp
+spec:
+  data:
+    - remoteRef:
+        key: 88c10a6c-268a-412a-b3d0-b4230026ba80
+      secretKey: RELAYHOST_PASSWORD
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden
+  target:
+    name: smtp

--- a/dist/smtp/Service.smtp.yaml
+++ b/dist/smtp/Service.smtp.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: smtp
+  namespace: smtp
+spec:
+  externalIPs: []
+  ports:
+    - name: http
+      port: 25
+      targetPort: 25
+  selector:
+    cdk8s.io/metadata.addr: smtp-app-smtp-app-deployment-c84da417
+  type: ClusterIP

--- a/dist/smtp/kustomization.yaml
+++ b/dist/smtp/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - Deployment.smtp.yaml
+  - ExternalSecret.smtp.yaml
+  - Service.smtp.yaml


### PR DESCRIPTION
## Summary

- Adds a Postfix-based SMTP relay in the `smtp` namespace using `boky/postfix`
- Internal cluster clients point to `smtp.smtp.svc.cluster.local:25` — no credentials needed
- Relay forwards upstream to Cloudflare (`smtp.mx.cloudflare.net:465`) via SMTPS (implicit TLS / wrappermode) using an API token from Bitwarden Secrets Manager
- No ingress — service is cluster-internal only

## Test plan

- [ ] ArgoApp syncs and namespace `smtp` is created
- [ ] Bitwarden ExternalSecret resolves (check `kubectl get externalsecret -n smtp`)
- [ ] Pod comes up healthy (`kubectl get pods -n smtp`)
- [ ] Send a test email from another pod: `curl --ssl-reqd --url 'smtp://smtp.smtp.svc.cluster.local:25' --mail-from 'test@example.com' --mail-rcpt 'you@example.com' --upload-file mail.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)