### PR TITLE
fix(paperless-ai): enable automatic document processing

### DIFF
--- a/apps/paperless/app.ts
+++ b/apps/paperless/app.ts
@@ -148,7 +148,7 @@ class Paperless extends Chart {
         ACTIVATE_TITLE: "yes",
         ACTIVATE_CUSTOM_FIELDS: "no",
         CUSTOM_FIELDS: '{"custom_fields":[]}',
-        DISABLE_AUTOMATIC_PROCESSING: "yes",
+        DISABLE_AUTOMATIC_PROCESSING: "no",
         RESTRICT_TO_EXISTING_TAGS: "yes",
         RESTRICT_TO_EXISTING_CORRESPONDENTS: "no",
         RESTRICT_TO_EXISTING_DOCUMENT_TYPES: "yes",

--- a/dist/paperless/ConfigMap.paperless-ai-config.yaml
+++ b/dist/paperless/ConfigMap.paperless-ai-config.yaml
@@ -15,7 +15,7 @@ data:
   CUSTOM_BASE_URL: https://gateway.ai.cloudflare.com/v1/5b51f634ca1cf16a0c47a4fcd00a5cf3/cmdcentral/compat
   CUSTOM_FIELDS: '{"custom_fields":[]}'
   CUSTOM_MODEL: workers-ai/@cf/zai-org/glm-4.7-flash
-  DISABLE_AUTOMATIC_PROCESSING: "yes"
+  DISABLE_AUTOMATIC_PROCESSING: "no"
   EXTERNAL_API_ENABLED: "no"
   PAPERLESS_API_URL: https://paperless.cmdcentral.xyz/api
   PAPERLESS_USERNAME: bschafer


### PR DESCRIPTION
## Summary

- `DISABLE_AUTOMATIC_PROCESSING` was set to `"yes"`, blocking the `SCAN_INTERVAL` cron from triggering autotagging
- Changed to `"no"` so paperless-ai will now automatically process documents every 30 minutes

## Test plan

- [ ] Verify paperless-ai processes documents automatically on the next scan interval after deploy